### PR TITLE
persist title on "previous"

### DIFF
--- a/views/new-steps/invoke.js
+++ b/views/new-steps/invoke.js
@@ -18,7 +18,8 @@ module.exports = function PickTimes ({ state, prev, next }) {
           placeholder: 'Name of gathering you\'re scrying for',
           'ev-input': ev => {
             state.title.set(ev.target.value)
-          }
+          },
+          'value': state.title
         },
         state.title
       ),


### PR DESCRIPTION
The title filed becomes blank when coming back from the "select dates" screen which is a little confusing.
This should fix that. I'm not sure if that is how its done in mutant, but it worked :D 