### PR TITLE
fix error on not-popular timezones

### DIFF
--- a/views/component/scry-card.js
+++ b/views/component/scry-card.js
@@ -11,7 +11,7 @@ module.exports = function ScryCard ({ scuttle, msg, mdRenderer, onClick }) {
 
   const closesAt = new Date(closesAtString)
   const date = closesAt.toDateString()
-  const [ _, time, zone ] = closesAt.toTimeString().match(/^(\d+:\d+).*(\([\w\s]+\))$/)
+  const [ , time, zone ] = closesAt.toTimeString().match(/^(\d+:\d+).*(\([+-\w\s\d]+\))$/)
 
   return h('ScryCard', { className: 'Markdown', 'ev-click': onClick }, [
     h('h1', title),


### PR DESCRIPTION
I get the following error on `/scry` pages
```
TypeError: Cannot read property 'Symbol(Symbol.iterator)' of closesAt.toTimeString(...).match
    at ScryCard (/media/avk/files/Programs/ssb/patchbay-scry/views/component/scry-card.js:23:6)
    at render (/media/avk/files/Programs/ssb/patchbay-scry/views/index.js:41:16)
    at updateItem (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant/map.js:227:24)
    at update (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant/map.js:106:11)
    at Object.updateAndBroadcast (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant/lib/lazy-watcher.js:54:18)
    at Array.onUpdate (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant/lib/lazy-watcher.js:48:13)
    at broadcast (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant/lib/lazy-watcher.js:111:27)
    at Object.broadcast (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant/lib/lazy-watcher.js:24:9)
    at Function.Array.observable.push (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant/array.js:50:12)
    at updateBottom (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant-scroll/index.js:23:48)
    at addBottom (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant-scroll/index.js:76:7)
    at fillPage (/media/avk/files/Programs/ssb/patchbay-scry/node_modules/mutant-scroll/index.js:149:5)
```

This is caused because JavaScript doesn't care about not popular timezones (https://www.timeanddate.com/time/zones/npt) :D 
Instead of NPT it shows as (+0545) which breaks the regexp for getting the timezones.

This change fixes the error for other timezones which might be a plus (+) or a minus(-) from GMT. 